### PR TITLE
feat: update config for going to production

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,10 +12,10 @@ const config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://swissdatasciencecenter.github.io",
+  url: "https://blog.renkulab.io",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/renku-blog/",
+  baseUrl: "/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Update config to use `https://blog.renkulab.io` as the blog's URL.