### PR TITLE
chore: avoid stalling devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm install && npm run start"
+  "postCreateCommand": "npm install"
 
   // Configure tool-specific properties.
   // "customizations": {},


### PR DESCRIPTION
If `npm run start` is in there, it can cause some issues with devcontainer tooling. 