### PR TITLE
chore: cleanup tags from blog posts

### DIFF
--- a/blog/2024-03-07-cloud-storage/index.mdx
+++ b/blog/2024-03-07-cloud-storage/index.mdx
@@ -6,7 +6,7 @@ authors: [elisabet]
 tags:
   - Cloud Storage
   - Data
-  - RenkuLab
+  - RenkuLab Update
   - Renku CLI
 image: ./image_1.png
 ---

--- a/blog/2024-03-22-renku-2-0/index.mdx
+++ b/blog/2024-03-22-renku-2-0/index.mdx
@@ -4,9 +4,9 @@ title: |
   Renku 2.0: Connecting the research ecosystem
 authors: [elisabet, rokroskar, laura]
 tags:
-  - renku 2.0
-  - research
-  - teaching
+  - Renku 2.0
+  - Research
+  - Teaching
 image: image_1.png
 ---
 


### PR DESCRIPTION
See:
https://renku-blog-ci-76.dev.renku.ch/tags/
vs
https://blog.renkulab.io/tags/