### PR TITLE
Modified links to Community Portal

### DIFF
--- a/blog/2024-03-22-renku-2-0/index.mdx
+++ b/blog/2024-03-22-renku-2-0/index.mdx
@@ -125,7 +125,6 @@ please [drop us an email](mailto:hello@renku.io)!
 Are you interested in learning more about Renku 2.0? If so, have a look at the following resources:
 
 - Watch our [Renku 2.0 webinar](https://youtu.be/6J0INjPFQd4) or view the [slides](https://drive.google.com/file/d/1empUHHTonffW1fhdB_3DCIH-yVUz3MU8/view?usp=share_link)
-- Check out the [Renku roadmap](https://github.com/SwissDataScienceCenter/renku-design-docs/blob/main/roadmap.md)
-- Give feedback on our [design docs](https://github.com/SwissDataScienceCenter/renku-design-docs/tree/main)
+- Check out the Renku roadmap and give feedback on our [design docs](https://renku.notion.site/Roadmap-b1342b798b0141399dc39cb12afc60c9)
 
 If you want to test Renku 2.0 beta or participate in UX research [contact us!](mailto:hello@renku.io) - we look forward to hearing from you!


### PR DESCRIPTION
Update blog 'roadmap' and 'design docs' links to point to the Community Portal