### PR TITLE
feat: configure trailing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM nginxinc/nginx-unprivileged:1.25-alpine
 
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+
 COPY build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginxinc/nginx-unprivileged:1.25-alpine
 
-COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --chown=nginx:root --chmod=664  nginx/default.conf /etc/nginx/conf.d/default.conf
 
 COPY build /usr/share/nginx/html

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,6 +17,8 @@ const config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",
+  // Do not include a trailing slash for article pages.
+  trailingSlash: false,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,8 +17,8 @@ const config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",
-  // Do not include a trailing slash for article pages.
-  trailingSlash: false,
+  // Include a trailing slash for article pages, which is what GitHub pages does by default.
+  trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,45 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    absolute_redirect off;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
Fixes a `location` header bug in PR deployments.