### PR TITLE
chore: add a note for redirects to sunsetting blogpost

### DIFF
--- a/blog/2025-06-01-sunsetting-legacy/index.mdx
+++ b/blog/2025-06-01-sunsetting-legacy/index.mdx
@@ -12,7 +12,7 @@ description: With the official launch of Renku 2.0, we're ready to sunset Renku 
 :::info
 
 You may have been redirected here after trying to create a Renku project or a Gitlab project on the Gitlab associated with Renku.
-We have currently disabled legacy project creation as part of sunsetting Renku Legacy.
+We have disabled legacy project creation as part of sunsetting Renku Legacy.
 To find out more, read the following blog post.
 
 :::

--- a/blog/2025-06-01-sunsetting-legacy/index.mdx
+++ b/blog/2025-06-01-sunsetting-legacy/index.mdx
@@ -9,6 +9,14 @@ image: ./sunset-legacy.jpg
 description: With the official launch of Renku 2.0, we're ready to sunset Renku Legacy (Renku “1.0”). Here's what you need to know and what you need to do.
 ---
 
+:::info
+
+You may have been redirected here after trying to create a Renku project or a Gitlab project on the Gitlab associated with Renku.
+We have currently disabled legacy project creation as part of sunsetting Renku Legacy.
+To find out more, read the following blog post.
+
+:::
+
 With the official launch of Renku 2.0, we're ready to sunset Renku Legacy (Renku “1.0”). Here's what
 you need to know and what you need to do.
 


### PR DESCRIPTION
We will disable creating gitlab projects by modifying the ingress to reject POST requests on the gitlab api that create projects.

The requests will redirect to the blog post about sunsetting. And a note at the top of the blog post will make sure users understand why they got here.