### PR TITLE
build: update config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,13 @@ const config = {
   projectName: "renku-blog", // Usually your repo name.
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+
+  // Markdown-related options.
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "warn",
+    },
+  },
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want


### PR DESCRIPTION
Address the following warning:
```
Warning:  The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```