### PR TITLE
feat: update footer links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,7 +150,7 @@ const config = {
                 label: "What is Renku",
                 href: "https://renku.notion.site/What-is-Renku-1900df2efafc80839b26cbad43f24778",
               },
-               {
+              {
                 label: "Roadmap",
                 href: "https://renku.notion.site/Roadmap-b1342b798b0141399dc39cb12afc60c9",
               },


### PR DESCRIPTION
footer updated:
- the current Why Renku? link, redirects to a 404 page
- Roadmap added