### PR TITLE
ignore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:1.29-alpine
+FROM nginxinc/nginx-unprivileged:1.31-alpine
 
 COPY --chown=nginx:root --chmod=664  nginx/default.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Bumps nginxinc/nginx-unprivileged from 1.29-alpine to 1.31-alpine.

---
updated-dependencies:
- dependency-name: nginxinc/nginx-unprivileged dependency-version: 1.31-alpine dependency-type: direct:production ...